### PR TITLE
Modified manual mode use correct value.  Added frostProtection mode.

### DIFF
--- a/custom_components/schluterditraheat/climate.py
+++ b/custom_components/schluterditraheat/climate.py
@@ -26,8 +26,11 @@ from .const import (
     MAX_TEMP_C,
     MIN_TEMP_C,
     MODE_AUTO,
+    MODE_FROST_SAFE,
     MODE_MANUAL,
     MODE_OFF,
+    PRESET_FROST_PROTECTION,
+    PRESET_NONE,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -55,9 +58,13 @@ class SchluterThermostat(CoordinatorEntity[SchluterDataUpdateCoordinator], Clima
 
     _attr_temperature_unit = UnitOfTemperature.CELSIUS
     _attr_supported_features = (
-        ClimateEntityFeature.TARGET_TEMPERATURE | ClimateEntityFeature.TURN_OFF | ClimateEntityFeature.TURN_ON
+        ClimateEntityFeature.TARGET_TEMPERATURE
+        | ClimateEntityFeature.TURN_OFF
+        | ClimateEntityFeature.TURN_ON
+        | ClimateEntityFeature.PRESET_MODE
     )
     _attr_hvac_modes = [HVACMode.HEAT, HVACMode.OFF, HVACMode.AUTO]
+    _attr_preset_modes = [PRESET_NONE, PRESET_FROST_PROTECTION]
 
     def __init__(
         self, coordinator: SchluterDataUpdateCoordinator, device_id: int
@@ -137,6 +144,17 @@ class SchluterThermostat(CoordinatorEntity[SchluterDataUpdateCoordinator], Clima
         return HVACAction.IDLE
 
     @property
+    def preset_mode(self) -> str | None:
+        """Return current preset mode."""
+        thermostat = self.coordinator.data.get(self._device_id, {})
+        mode = thermostat.get("mode")
+        if mode == MODE_FROST_SAFE:
+            return PRESET_FROST_PROTECTION
+        if mode in (MODE_MANUAL, MODE_AUTO, MODE_OFF):
+            return PRESET_NONE
+        return None
+
+    @property
     def min_temp(self) -> float:
         """Return the minimum temperature."""
         return MIN_TEMP_C
@@ -187,6 +205,24 @@ class SchluterThermostat(CoordinatorEntity[SchluterDataUpdateCoordinator], Clima
         await self.coordinator.api.set_mode(self._device_id, mode)
 
         # Optimistic update — push new value to UI immediately
+        if self._device_id in self.coordinator.data:
+            self.coordinator.data[self._device_id]["mode"] = mode
+            self.async_write_ha_state()
+
+        await self.coordinator.async_request_refresh()
+
+    async def async_set_preset_mode(self, preset_mode: str) -> None:
+        """Set new preset mode."""
+        if preset_mode == PRESET_FROST_PROTECTION:
+            mode = MODE_FROST_SAFE
+        elif preset_mode == PRESET_NONE:
+            mode = MODE_MANUAL
+        else:
+            _LOGGER.error("Unsupported preset mode: %s", preset_mode)
+            return
+
+        await self.coordinator.api.set_mode(self._device_id, mode)
+
         if self._device_id in self.coordinator.data:
             self.coordinator.data[self._device_id]["mode"] = mode
             self.async_write_ha_state()

--- a/custom_components/schluterditraheat/const.py
+++ b/custom_components/schluterditraheat/const.py
@@ -35,4 +35,12 @@ ATTR_LOCATION_NAME = "location_name"
 # Modes
 MODE_AUTO = "auto"
 MODE_OFF = "off"
-MODE_MANUAL = "autoBypass"  # For manual temperature override
+MODE_MANUAL = "manual"
+MODE_FROST_SAFE = "frostProtection"
+
+# Preset modes — only needed for modes that have no HVACMode enum equivalent.
+# auto/manual/off map to HVACMode.AUTO/HEAT/OFF so HA owns those labels.
+# Frost protection has no HVACMode, so it uses a plain string that must be
+# declared here to avoid scattering the literal across the codebase.
+PRESET_NONE = "none"
+PRESET_FROST_PROTECTION = "frost_protection"

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -8,8 +8,11 @@ import pytest
 from custom_components.schluterditraheat.climate import SchluterThermostat
 from custom_components.schluterditraheat.const import (
     MODE_AUTO,
+    MODE_FROST_SAFE,
     MODE_MANUAL,
     MODE_OFF,
+    PRESET_FROST_PROTECTION,
+    PRESET_NONE,
 )
 
 
@@ -111,6 +114,31 @@ class TestClimateProperties:
         coordinator.data[40001]["mode"] = MODE_OFF
         assert thermostat.hvac_action == HVACAction.OFF
 
+    def test_preset_mode_none_when_manual(self, thermostat, coordinator):
+        """Test preset_mode returns PRESET_NONE for manual mode."""
+        coordinator.data[40001]["mode"] = MODE_MANUAL
+        assert thermostat.preset_mode == PRESET_NONE
+
+    def test_preset_mode_none_when_auto(self, thermostat, coordinator):
+        """Test preset_mode returns PRESET_NONE for auto (schedule) mode."""
+        coordinator.data[40001]["mode"] = MODE_AUTO
+        assert thermostat.preset_mode == PRESET_NONE
+
+    def test_preset_mode_none_when_off(self, thermostat, coordinator):
+        """Test preset_mode returns PRESET_NONE when off."""
+        coordinator.data[40001]["mode"] = MODE_OFF
+        assert thermostat.preset_mode == PRESET_NONE
+
+    def test_preset_mode_frost_protection(self, thermostat, coordinator):
+        """Test preset_mode returns PRESET_FROST_PROTECTION for frostProtection mode."""
+        coordinator.data[40001]["mode"] = MODE_FROST_SAFE
+        assert thermostat.preset_mode == PRESET_FROST_PROTECTION
+
+    def test_preset_mode_unknown_returns_none(self, thermostat, coordinator):
+        """Test preset_mode returns None for an unrecognized API mode."""
+        coordinator.data[40001]["mode"] = "someNewUnknownMode"
+        assert thermostat.preset_mode is None
+
     def test_min_max_temp(self, thermostat):
         """Test min/max temperature limits."""
         assert thermostat.min_temp == 5.0
@@ -178,3 +206,28 @@ class TestOptimisticUpdates:
 
         coordinator.api.set_mode.assert_called_once_with(40001, MODE_OFF)
         assert coordinator.data[40001]["mode"] == MODE_OFF
+
+    async def test_set_preset_mode_frost_protection(self, thermostat, coordinator):
+        """Test that set_preset_mode frost_protection sends frostProtection to API."""
+        await thermostat.async_set_preset_mode(PRESET_FROST_PROTECTION)
+
+        coordinator.api.set_mode.assert_called_once_with(40001, MODE_FROST_SAFE)
+        assert coordinator.data[40001]["mode"] == MODE_FROST_SAFE
+        thermostat.async_write_ha_state.assert_called_once()
+        coordinator.async_request_refresh.assert_called_once()
+
+    async def test_set_preset_mode_none_maps_to_manual(self, thermostat, coordinator):
+        """Test that set_preset_mode none sends manual to API."""
+        coordinator.data[40001]["mode"] = MODE_FROST_SAFE  # start in frost protection
+
+        await thermostat.async_set_preset_mode(PRESET_NONE)
+
+        coordinator.api.set_mode.assert_called_once_with(40001, MODE_MANUAL)
+        assert coordinator.data[40001]["mode"] == MODE_MANUAL
+        thermostat.async_write_ha_state.assert_called_once()
+
+    async def test_set_preset_mode_unsupported_is_noop(self, thermostat, coordinator):
+        """Test that an unsupported preset mode does not call the API."""
+        await thermostat.async_set_preset_mode("turbo_mode")
+
+        coordinator.api.set_mode.assert_not_called()


### PR DESCRIPTION
Proposed fix for issue #2 

**Summary**
- Corrects MODE_MANUAL from "autoBypass" to "manual" to match the actual Schluter API setpointMode value
- Adds MODE_FROST_SAFE = "frostProtection" for the frost protection operating mode
- Exposes frost protection as a selectable HA preset mode (frost_protection) on the climate entity

Adds tests for all new preset mode behavior
**Changes**
const.py
- MODE_MANUAL: "autoBypass" → "manual"
- Added MODE_FROST_SAFE = "frostProtection"
- Added PRESET_NONE = "none" and PRESET_FROST_PROTECTION = "frost_protection"

climate.py
- Added ClimateEntityFeature.PRESET_MODE to supported features
- Added _attr_preset_modes = [PRESET_NONE, PRESET_FROST_PROTECTION]
- Added preset_mode property — returns frost_protection when API mode is frostProtection, none otherwise
- Added async_set_preset_mode — translates HA preset strings to API mode values with optimistic update

**Mode mapping**

|HA HVAC mode | HA Preset API | setpointMode | 
|Heat | none | manual |
|Heat | frost_protection | frostProtection |
|Auto | none | auto |
|Off | — | off |
Frost protection is implemented as a preset rather than an HVAC mode because HVACMode is a fixed HA enum with no frost protection equivalent. Presets are the idiomatic HA extension point for device-specific sub-modes.

**Test plan**
All existing tests pass
New TestClimateProperties tests cover preset_mode for all four API mode values including unknown values
New TestOptimisticUpdates tests cover async_set_preset_mode for frost protection, none, and unsupported presets
Live smoke test against real API confirms "frostProtection" and "manual" are accepted by the device

Mode test with patch applied,
```
  Original mode: 'off'  |  Original setpoint: 26.66
  → Setting mode to 'OFF' ('off') ... OK
  → Setting mode to 'AUTO' ('auto') ... OK
  → Setting mode to 'HEAT / autoBypass' ('manual') ... OK
  → Setting mode to 'FROSTSAFE' ('frostProtection') ... OK
```